### PR TITLE
Use config-map to store environment variables set by Slurm

### DIFF
--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -92,3 +92,25 @@ spec:
   selector:
     matchLabels:
       app: k8s-slurm-injector
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-slurm-injector-role
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-slurm-injector-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-slurm-injector-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: k8s-slurm-injector

--- a/go.mod
+++ b/go.mod
@@ -4,20 +4,18 @@ go 1.15
 
 require (
 	github.com/coreos/prometheus-operator v0.39.0
-	github.com/google/goexpect v0.0.0-20200816234442-b5b77125c2c5
-	github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2 // indirect
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.8.0
-	github.com/prometheus/common v0.14.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/slok/go-http-metrics v0.6.1
 	github.com/slok/kubewebhook/v2 v2.0.0-beta.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
-	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4
+	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.19.6
 	k8s.io/apimachinery v0.19.6
+	k8s.io/client-go v12.0.0+incompatible
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.19.6

--- a/go.sum
+++ b/go.sum
@@ -256,7 +256,6 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -923,7 +922,6 @@ google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBr
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/go.sum
+++ b/go.sum
@@ -111,7 +111,6 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coreos/bbolt v1.3.1-coreos.6/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -160,7 +159,6 @@ github.com/emicklei/go-restful v2.11.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQm
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -293,15 +291,10 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/goexpect v0.0.0-20200816234442-b5b77125c2c5 h1:WgPsDN4gp2CYXtwRcIgjbx4TmWX8XumZI9Q8iJov450=
-github.com/google/goexpect v0.0.0-20200816234442-b5b77125c2c5/go.mod h1:n1ej5+FqyEytMt/mugVDZLIiqTMO+vsrgY+kM6ohzN0=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
-github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2 h1:CVuJwN34x4xM2aT4sIKhmeib40NeBPhRihNjQmpJsA4=
-github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -318,6 +311,7 @@ github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyycI+I=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
@@ -374,6 +368,7 @@ github.com/hashicorp/serf v0.8.5/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
@@ -661,7 +656,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b/go.mod h1:IZpXDfkJ6tWD3PhBK5YzgQT+xJWh7OsdwiG8hA2MkO4=
 go.elastic.co/apm v1.5.0/go.mod h1:OdB9sPtM6Vt7oz3VXt7+KR96i9li74qrxBGHTQygFvk=
 go.elastic.co/apm/module/apmhttp v1.5.0/go.mod h1:1FbmNuyD3ddauwzgVwFB0fqY6KbZt3JkV187tGCYYhY=
 go.elastic.co/apm/module/apmot v1.5.0/go.mod h1:d2KYwhJParTpyw2WnTNy8geNlHKKFX+4oK3YLlsesWE=
@@ -707,7 +701,6 @@ golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -775,6 +768,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 h1:pE8b58s1HRDMi8RDc79m0HISf9D4TzseP40cEA6IGfs=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -847,6 +841,7 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -912,6 +907,7 @@ google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -943,8 +939,6 @@ google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRn
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
-google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -1048,6 +1042,7 @@ k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K8Hf8whTseBgJcg=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=

--- a/internal/http/slurm/handler.go
+++ b/internal/http/slurm/handler.go
@@ -1,13 +1,18 @@
 package slurm
 
 import (
+	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/json"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/d-hayashi/k8s-slurm-injector/internal/mutation/sidecar"
 	"github.com/d-hayashi/k8s-slurm-injector/internal/ssh_handler"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type SbatchHandler struct {
@@ -18,12 +23,22 @@ type JobEnvHandler struct {
 	handler handler
 }
 
+type JobEnvToConfigMapHandler struct {
+	JobEnvHandler
+}
+
 type JobStateHandler struct {
 	handler handler
 }
 
 type ScancelHandler struct {
 	handler handler
+}
+
+func ConfigMapNameFromObjectName(objectName string) string {
+	regString := regexp.MustCompile(`[^0-9A-Za-z_#:-]`)
+	name := regString.ReplaceAllString(objectName, "")
+	return fmt.Sprintf("k8s-slurm-injector-config-%s", name)
 }
 
 func (s SbatchHandler) parseQueryParams(r *http.Request, jobInfo *sidecar.JobInformation) error {
@@ -156,23 +171,29 @@ func (h handler) sbatch() (http.Handler, error) {
 	return SbatchHandler{h}, nil
 }
 
-func (s JobEnvHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	jobid := r.URL.Query().Get("jobid")
-	s.handler.logger.Infof("state jobid=%s", jobid)
-
-	if jobid == "" {
-		s.handler.logger.Errorf("jobid is not given")
-		return
-	}
-
+func getEnv(jobid string, s *JobEnvHandler) (string, error) {
 	command := ssh_handler.SSHCommand{
 		Command: fmt.Sprintf("srun --jobid=%s env", jobid),
 	}
 	out, err := s.handler.ssh.RunCommand(command)
+	return string(out), err
+}
+
+func (s JobEnvHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	jobid := r.URL.Query().Get("jobid")
+	s.handler.logger.Infof("env jobid=%s", jobid)
+
+	if jobid == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		s.handler.logger.Errorf("jobid is not given")
+		return
+	}
+
+	out, err := getEnv(jobid, &s)
 
 	// Write to respond
 	if err == nil {
-		_, _ = fmt.Fprint(w, string(out))
+		_, _ = fmt.Fprint(w, out)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 		s.handler.logger.Errorf("failed to get envrionment variables of job: %s", err.Error())
@@ -183,11 +204,113 @@ func (h handler) jobEnv() (http.Handler, error) {
 	return JobEnvHandler{h}, nil
 }
 
+func (s JobEnvToConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	jobid := r.URL.Query().Get("jobid")
+	namespace := r.URL.Query().Get("namespace")
+	objectName := r.URL.Query().Get("objectname")
+	configMapName := ConfigMapNameFromObjectName(objectName)
+	s.handler.logger.Infof("envToConfigMap jobid=%s, configmap=%s, namespace=%s", jobid, configMapName, namespace)
+
+	if jobid == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		s.handler.logger.Errorf("jobid is not given")
+		return
+	}
+	if objectName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		s.handler.logger.Errorf("objectname is not given")
+		return
+	}
+	if namespace == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		s.handler.logger.Errorf("namespace is not given")
+		return
+	}
+
+	out, err := getEnv(jobid, &s.JobEnvHandler)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		s.handler.logger.Errorf("failed to get envrionment variables of job: %s", err.Error())
+		return
+	}
+
+	// Get config-map if exists
+	cm, err := s.handler.clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// Create a config-map
+		s.handler.logger.Infof("creating a new config-map: %s", configMapName)
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: namespace,
+				Labels:    nil,
+				Annotations: map[string]string{
+					"k8s-slurm-injector/jobid": jobid,
+				},
+			},
+			Immutable: nil,
+			Data: map[string]string{
+				"env": out,
+			},
+			BinaryData: nil,
+		}
+		_, err := s.handler.clientset.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			s.handler.logger.Errorf("error updating configmap '%s': %s", configMapName, err.Error())
+			return
+		}
+	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+		w.WriteHeader(http.StatusInternalServerError)
+		s.handler.logger.Errorf("error getting configmap %v", statusError.ErrStatus.Message)
+		return
+	} else if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		s.handler.logger.Errorf("error getting configmap: %s", err.Error())
+		return
+	} else {
+		// Update config-map
+		s.handler.logger.Infof("updating config-map: %s", configMapName)
+		bytes, err := json.Marshal(cm)
+		if err != nil {
+			s.handler.logger.Warningf("failed to jsonify previous-configuration")
+			bytes = []byte{}
+		}
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: namespace,
+				Labels:    nil,
+				Annotations: map[string]string{
+					"k8s-slurm-injector/jobid":                      jobid,
+					"k8s-slurm-injector/last-applied-configuration": string(bytes),
+				},
+			},
+			Immutable: nil,
+			Data: map[string]string{
+				"env": out,
+			},
+			BinaryData: nil,
+		}
+		_, err = s.handler.clientset.CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			s.handler.logger.Errorf("error updating configmap '%s': %s", configMapName, err.Error())
+			return
+		}
+	}
+}
+
+func (h handler) jobEnvToConfigMap() (http.Handler, error) {
+	return JobEnvToConfigMapHandler{JobEnvHandler{h}}, nil
+}
+
 func (s JobStateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	jobid := r.URL.Query().Get("jobid")
 	s.handler.logger.Infof("state jobid=%s", jobid)
 
 	if jobid == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		s.handler.logger.Errorf("jobid is not given")
 		return
 	}
@@ -221,11 +344,34 @@ func (h handler) jobState() (http.Handler, error) {
 
 func (s ScancelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	jobid := r.URL.Query().Get("jobid")
+	namespace := r.URL.Query().Get("namespace")
+	objectName := r.URL.Query().Get("objectname")
+	configMapName := ConfigMapNameFromObjectName(objectName)
 	s.handler.logger.Infof("scancel jobid=%s", jobid)
 
 	if jobid == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		s.handler.logger.Errorf("jobid is not given")
 		return
+	}
+	if objectName != "" && namespace != "" {
+		// Delete the corresponding config-map if exists
+		_, err := s.handler.clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			s.handler.logger.Warningf("config-map '%s' does not exist, skipped deleting it", configMapName)
+		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+			s.handler.logger.Errorf("error getting configmap %v", statusError.ErrStatus.Message)
+		} else if err != nil {
+			s.handler.logger.Errorf("error getting configmap: %s", err.Error())
+		} else {
+			// The corresponding config-map exists
+			s.handler.logger.Infof("deleting config-map: %s", configMapName)
+			err = s.handler.clientset.CoreV1().ConfigMaps(namespace).Delete(context.TODO(), configMapName, metav1.DeleteOptions{})
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				s.handler.logger.Errorf("error deleting configmap '%s': %s", configMapName, err.Error())
+			}
+		}
 	}
 
 	var out []byte

--- a/internal/http/slurm/routes.go
+++ b/internal/http/slurm/routes.go
@@ -18,6 +18,12 @@ func (h handler) routes(router *http.ServeMux) error {
 	}
 	router.Handle("/slurm/env", jobEnv)
 
+	jobEnvToConfigMap, err := h.jobEnvToConfigMap()
+	if err != nil {
+		return err
+	}
+	router.Handle("/slurm/envtoconfigmap", jobEnvToConfigMap)
+
 	jobState, err := h.jobState()
 	if err != nil {
 		return err

--- a/internal/http/slurm/webhook.go
+++ b/internal/http/slurm/webhook.go
@@ -2,16 +2,16 @@ package slurm
 
 import (
 	"fmt"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"net/http"
 	"path/filepath"
 	"strings"
 
 	"github.com/d-hayashi/k8s-slurm-injector/internal/log"
 	"github.com/d-hayashi/k8s-slurm-injector/internal/ssh_handler"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
 // Config is the handler configuration.

--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -40,6 +40,8 @@ type sidecarinjector struct {
 }
 
 type JobInformation struct {
+	Namespace             string
+	ObjectName            string
 	NodeSpecificationMode string
 	Partition             string
 	Node                  string
@@ -53,6 +55,8 @@ type JobInformation struct {
 
 func NewJobInformation() *JobInformation {
 	jobInfo := JobInformation{
+		Namespace:             "",
+		ObjectName:            "",
 		NodeSpecificationMode: "auto",
 		Partition:             "",
 		Node:                  "",
@@ -168,6 +172,8 @@ func (s sidecarinjector) getSlurmWebhookURL() string {
 
 func (s sidecarinjector) getJobInformation(obj metav1.Object, jobInfo *JobInformation) error {
 	var podSpec corev1.PodSpec
+	namespace := ""
+	objectname := ""
 	labels := obj.GetLabels()
 	ntasks := int64(1)
 	ncpus := int64(0)
@@ -178,11 +184,19 @@ func (s sidecarinjector) getJobInformation(obj metav1.Object, jobInfo *JobInform
 	switch v := obj.(type) {
 	case *corev1.Pod:
 		podSpec = v.Spec
+		namespace = v.Namespace
+		objectname = fmt.Sprintf("pod-%s", v.Name)
 	case *batchv1.Job:
 		podSpec = v.Spec.Template.Spec
+		namespace = v.Namespace
+		objectname = fmt.Sprintf("job-%s", v.Name)
 	case *batchv1beta1.CronJob:
 		podSpec = v.Spec.JobTemplate.Spec.Template.Spec
+		namespace = v.Namespace
+		objectname = fmt.Sprintf("cronjob-%s", v.Name)
 	}
+	jobInfo.Namespace = namespace
+	jobInfo.ObjectName = objectname
 
 	// Get labels
 	if labels == nil {
@@ -295,9 +309,10 @@ func (s sidecarinjector) getJobInformation(obj metav1.Object, jobInfo *JobInform
 	return nil
 }
 
-func (s sidecarinjector) constructSbatchURL(slurmWebhookURL string, jobInfo JobInformation) string {
-	sbatchURL := slurmWebhookURL +
-		"/slurm/sbatch?" +
+func (s sidecarinjector) constructURL(slurmWebhookURL string, jobInfo JobInformation, action string) string {
+	url := slurmWebhookURL + "/slurm/" + action + "?" +
+		fmt.Sprintf("namespace=%s&", jobInfo.Namespace) +
+		fmt.Sprintf("objectname=%s&", jobInfo.ObjectName) +
 		fmt.Sprintf("nodespecificationmode=%s&", jobInfo.NodeSpecificationMode) +
 		fmt.Sprintf("partition=%s&", jobInfo.Partition) +
 		fmt.Sprintf("node=%s&", jobInfo.Node) +
@@ -307,7 +322,9 @@ func (s sidecarinjector) constructSbatchURL(slurmWebhookURL string, jobInfo JobI
 		fmt.Sprintf("time=%s&", jobInfo.Time) +
 		fmt.Sprintf("name=%s&", jobInfo.Name)
 
-	return sbatchURL
+	url = strings.TrimSuffix(url, "&")
+
+	return url
 }
 
 func (s sidecarinjector) mutateObject(obj metav1.Object) error {
@@ -327,13 +344,17 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 		return fmt.Errorf("unsupported type")
 	}
 
-	// Construct sbatch URL
+	// Construct URLs
 	slurmWebhookURL := s.getSlurmWebhookURL()
 	err = s.getJobInformation(obj, &jobInfo)
 	if err != nil {
 		return fmt.Errorf("failed to get job-information: %s", err.Error())
 	}
-	sbatchURL := s.constructSbatchURL(slurmWebhookURL, jobInfo)
+	sbatchURL := s.constructURL(slurmWebhookURL, jobInfo, "sbatch")
+	stateURL := s.constructURL(slurmWebhookURL, jobInfo, "state")
+	envURL := s.constructURL(slurmWebhookURL, jobInfo, "envtoconfigmap")
+	scancelURL := s.constructURL(slurmWebhookURL, jobInfo, "scancel")
+	configMapName := fmt.Sprintf("k8s-slurm-injector-config-%s", jobInfo.ObjectName)
 
 	// Enable shareProcessNamespace
 	shareProcessNamespace := true
@@ -356,7 +377,7 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 		},
 		Args: []string{
 			"set -x; " +
-				fmt.Sprintf("slurmWebhookURL=\"%s\" && ", slurmWebhookURL) +
+				fmt.Sprintf("stateURL=\"%s\" && ", stateURL) +
 				fmt.Sprintf("sbatchURL=\"%s\" && ", sbatchURL) +
 				fmt.Sprintf("nodeName=\"%s\"; ", jobInfo.Node) +
 				"if [[ ${nodeName} = \"::K8S_SLURM_INJECTOR_NODE::\" ]]; " +
@@ -370,7 +391,7 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 				"do " +
 				"sleep 1; " +
 				"echo \"$jobid\" | egrep -q '^[0-9]+$' || exit 1; " +
-				"state=$(curl -s ${slurmWebhookURL}/slurm/state?jobid=${jobid}); " +
+				"state=$(curl -s \"${stateURL}&jobid=${jobid}\"); " +
 				"[[ \"$state\" = \"PENDING\" ]] && continue; " +
 				"[[ \"$state\" = \"RUNNING\" ]] && break; " +
 				"[[ \"$state\" = \"CANCELLED\" ]] && exit 1; " +
@@ -393,13 +414,13 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 		Args: []string{
 			fmt.Sprintf(
 				"set -x; "+
-					"url=%s; "+
+					"url=\"%s\"; "+
 					"jobid=$(cat /k8s-slurm-injector/jobid); "+
 					"[[ $jobid = \"\" ]] && echo 'Failed to get job-id' >&2 && exit 1; "+
 					"[[ $jobid = \"error\" ]] && echo 'Failed to get job-id' >&2 && exit 1; "+
 					"trap 'exit 1' SIGHUP SIGINT SIGQUIT SIGTERM ; "+
-					"curl -s \"${url}/slurm/env?jobid=${jobid}\" > /k8s-slurm-injector/env || exit 1",
-				slurmWebhookURL),
+					"curl -s \"${url}&jobid=${jobid}\" > /k8s-slurm-injector/env || exit 1",
+				envURL),
 		},
 		ImagePullPolicy: "IfNotPresent",
 		VolumeMounts: []corev1.VolumeMount{
@@ -437,19 +458,30 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 
 		// Set `CUDA_VISIBLE_DEVICES` in case GPU resources are not scheduled by kubernetes
 		if !jobInfo.GpuLimit && jobInfo.Gres != "" {
-			env := corev1.EnvVar{
-				Name:  "K8S_SLURM_INJECTOR_COMMAND",
-				Value: "export $(grep CUDA_VISIBLE_DEVICES /k8s-slurm-injector/env | xargs) > /dev/null && exec \"$@\"",
-			}
-			command := []string{
-				"sh",
-				"-c",
-				"echo ${K8S_SLURM_INJECTOR_COMMAND} | sh -s -- $0 $@",
-			}
-			args := append(podSpec.Containers[i].Command, podSpec.Containers[i].Args...)
-			podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, env)
-			podSpec.Containers[i].Command = command
-			podSpec.Containers[i].Args = args
+			//env := corev1.EnvVar{
+			//	Name:  "K8S_SLURM_INJECTOR_COMMAND",
+			//	Value: "export $(grep CUDA_VISIBLE_DEVICES /k8s-slurm-injector/env | xargs) > /dev/null && exec \"$@\"",
+			//}
+			//command := []string{
+			//	"sh",
+			//	"-c",
+			//	"echo ${K8S_SLURM_INJECTOR_COMMAND} | sh -s -- $0 $@",
+			//}
+			//args := append(podSpec.Containers[i].Command, podSpec.Containers[i].Args...)
+			//podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, env)
+			//podSpec.Containers[i].Command = command
+			//podSpec.Containers[i].Args = args
+			optional := true
+			podSpec.Containers[i].EnvFrom = append(podSpec.Containers[i].EnvFrom,
+				corev1.EnvFromSource{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMapName,
+						},
+						Optional: &optional,
+					},
+				},
+			)
 		}
 	}
 
@@ -459,39 +491,38 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 		Image:   "curlimages/curl:7.75.0",
 		Command: []string{"/bin/sh", "-c"},
 		Args: []string{
-			fmt.Sprintf(
-				"url=%s; "+
-					"jobid=$(cat /k8s-slurm-injector/jobid); "+
-					"[[ $jobid = \"\" ]] && echo 'Failed to get job-id' >&2 && exit 1; "+
-					"[[ $jobid = \"error\" ]] && echo 'Failed to get job-id' >&2 && exit 1; "+
-					"getState() { curl -s \"${url}/slurm/state?jobid=${jobid}\"; }; "+
-					"scancel() { curl -s \"${url}/slurm/scancel?jobid=${jobid}\"; }; "+
-					"trap 'scancel' SIGHUP SIGINT SIGQUIT SIGTERM ; "+
-					"count=0; "+
-					"while [[ $count -lt 10 ]]; "+
-					"do "+
-					"[[ -f /k8s-slurm-injector/container_id_0 ]] && break; "+
-					"sleep 1; "+
-					"count=$((count+1)); "+
-					"done; "+
-					"[[ $count -ge 10 ]] && scancel && exit 1; "+
-					"cid=$(cat /k8s-slurm-injector/container_id_0); "+
-					"[[ $cid = \"\" ]] && (echo 'Failed to get container_id' >&2; scancel) && exit 1; "+
-					"while true; "+
-					"do "+
-					"sleep 1; "+
-					"cat /proc/*/cgroup | grep ${cid} > /dev/null || break; "+
-					"state=$(getState); "+
-					"[[ \"$state\" = \"COMPLETING\" ]] && break; "+
-					"[[ \"$state\" = \"CANCELLED\" ]] && break; "+
-					"done; "+
-					"for pid in $(cd /proc && echo [0-9]* | tr \" \" \"\\n\" | sort -n); "+
-					"do "+
-					"cat /proc/${pid}/cgroup | grep ${cid} >/dev/null && kill -9 ${pid} "+
-					"&& echo \"Process ${pid} has been killed by slurm.\" >&2; "+
-					"done; "+
-					"scancel",
-				slurmWebhookURL),
+			fmt.Sprintf("stateURL=\"%s\"; ", stateURL) +
+				fmt.Sprintf("scancelURL=\"%s\"; ", scancelURL) +
+				"jobid=$(cat /k8s-slurm-injector/jobid); " +
+				"[[ $jobid = \"\" ]] && echo 'Failed to get job-id' >&2 && exit 1; " +
+				"[[ $jobid = \"error\" ]] && echo 'Failed to get job-id' >&2 && exit 1; " +
+				"getState() { curl -s \"${stateURL}&jobid=${jobid}\"; }; " +
+				"scancel() { curl -s \"${scancelURL}&jobid=${jobid}\"; }; " +
+				"trap 'scancel' SIGHUP SIGINT SIGQUIT SIGTERM ; " +
+				"count=0; " +
+				"while [[ $count -lt 10 ]]; " +
+				"do " +
+				"[[ -f /k8s-slurm-injector/container_id_0 ]] && break; " +
+				"sleep 1; " +
+				"count=$((count+1)); " +
+				"done; " +
+				"[[ $count -ge 10 ]] && scancel && exit 1; " +
+				"cid=$(cat /k8s-slurm-injector/container_id_0); " +
+				"[[ $cid = \"\" ]] && (echo 'Failed to get container_id' >&2; scancel) && exit 1; " +
+				"while true; " +
+				"do " +
+				"sleep 1; " +
+				"cat /proc/*/cgroup | grep ${cid} > /dev/null || break; " +
+				"state=$(getState); " +
+				"[[ \"$state\" = \"COMPLETING\" ]] && break; " +
+				"[[ \"$state\" = \"CANCELLED\" ]] && break; " +
+				"done; " +
+				"for pid in $(cd /proc && echo [0-9]* | tr \" \" \"\\n\" | sort -n); " +
+				"do " +
+				"cat /proc/${pid}/cgroup | grep ${cid} >/dev/null && kill -9 ${pid} " +
+				"&& echo \"Process ${pid} has been killed by slurm.\" >&2; " +
+				"done; " +
+				"scancel",
 		},
 		ImagePullPolicy: "IfNotPresent",
 		VolumeMounts: []corev1.VolumeMount{
@@ -530,6 +561,8 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 		annotations = map[string]string{}
 	}
 	annotations["k8s-slurm-injector/status"] = "injected"
+	annotations["k8s-slurm-injector/namespace"] = jobInfo.Namespace
+	annotations["k8s-slurm-injector/objectname"] = jobInfo.ObjectName
 	annotations["k8s-slurm-injector/node-specification-mode"] = jobInfo.NodeSpecificationMode
 	annotations["k8s-slurm-injector/partition"] = jobInfo.Partition
 	annotations["k8s-slurm-injector/node"] = jobInfo.Node

--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -456,33 +456,18 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 		podSpec.Containers[i].Lifecycle = &lifecycle
 		podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, volumeMount)
 
-		// Set `CUDA_VISIBLE_DEVICES` in case GPU resources are not scheduled by kubernetes
-		if !jobInfo.GpuLimit && jobInfo.Gres != "" {
-			//env := corev1.EnvVar{
-			//	Name:  "K8S_SLURM_INJECTOR_COMMAND",
-			//	Value: "export $(grep CUDA_VISIBLE_DEVICES /k8s-slurm-injector/env | xargs) > /dev/null && exec \"$@\"",
-			//}
-			//command := []string{
-			//	"sh",
-			//	"-c",
-			//	"echo ${K8S_SLURM_INJECTOR_COMMAND} | sh -s -- $0 $@",
-			//}
-			//args := append(podSpec.Containers[i].Command, podSpec.Containers[i].Args...)
-			//podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, env)
-			//podSpec.Containers[i].Command = command
-			//podSpec.Containers[i].Args = args
-			optional := true
-			podSpec.Containers[i].EnvFrom = append(podSpec.Containers[i].EnvFrom,
-				corev1.EnvFromSource{
-					ConfigMapRef: &corev1.ConfigMapEnvSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: configMapName,
-						},
-						Optional: &optional,
+		// Set environment variables allocated by Slurm
+		optional := true
+		podSpec.Containers[i].EnvFrom = append(podSpec.Containers[i].EnvFrom,
+			corev1.EnvFromSource{
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: configMapName,
 					},
+					Optional: &optional,
 				},
-			)
-		}
+			},
+		)
 	}
 
 	// Add container `slurm-watcher` as sidecar

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -47,6 +47,8 @@ func TestSidecarinjector_Inject(t *testing.T) {
 						"k8s-slurm-injector/node":                    "node1",
 					},
 					Annotations: map[string]string{
+						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/objectname":              "pod-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "manual",
 						"k8s-slurm-injector/partition":               "",
@@ -126,6 +128,8 @@ func TestSidecarinjector_Inject(t *testing.T) {
 						"k8s-slurm-injector/node":                    "node1",
 					},
 					Annotations: map[string]string{
+						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/objectname":              "job-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "manual",
 						"k8s-slurm-injector/partition":               "",
@@ -177,6 +181,8 @@ func TestSidecarinjector_Inject(t *testing.T) {
 						"k8s-slurm-injector/node-specification-mode": "auto",
 					},
 					Annotations: map[string]string{
+						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/objectname":              "pod-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "auto",
 						"k8s-slurm-injector/partition":               "",
@@ -239,6 +245,8 @@ func TestSidecarinjector_Inject(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
+						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/objectname":              "pod-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "",
 						"k8s-slurm-injector/partition":               "",


### PR DESCRIPTION
## What?
Use config-map to store environment variables set by Slurm.

## Why?
Bug fix

## Note
The previous version modifies the command and arguments of the containers to load environment variables set by slurm.  
But, this method does not work if no commands or arguments are specified in the manifest.  