### PR TITLE
Create a config-map on injecting sidecars

### DIFF
--- a/cmd/k8s-slurm-injector/main.go
+++ b/cmd/k8s-slurm-injector/main.go
@@ -80,7 +80,7 @@ func runApp() error {
 		return fmt.Errorf("failed to initialize finalizer: %s", err)
 	}
 
-	sidecarInjector, err := sidecar.NewSidecarInjector(sshHandler)
+	sidecarInjector, err := sidecar.NewSidecarInjector(sshHandler, configMapHandler)
 	if err != nil {
 		return fmt.Errorf("failed to initialize sidecar injector: %w", err)
 	}

--- a/internal/http/slurm/handler.go
+++ b/internal/http/slurm/handler.go
@@ -138,6 +138,7 @@ func (s SbatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				s.handler.logger.Errorf("error updating configmap '%s': %s", configMapName, err.Error())
 				return
 			}
+			s.handler.logger.Infof("created config-map '%s'", configMapName)
 		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
 			w.WriteHeader(http.StatusInternalServerError)
 			s.handler.logger.Errorf("error getting configmap %v", statusError.ErrStatus.Message)
@@ -155,6 +156,7 @@ func (s SbatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				s.handler.logger.Errorf("error updating configmap '%s': %s", configMapName, err.Error())
 				return
 			}
+			s.handler.logger.Infof("updated config-map '%s'", configMapName)
 		}
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -320,7 +322,7 @@ func (h handler) jobEnvToConfigMap() (http.Handler, error) {
 
 func (s JobStateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	jobid := r.URL.Query().Get("jobid")
-	s.handler.logger.Infof("state jobid=%s", jobid)
+	s.handler.logger.Debugf("state jobid=%s", jobid)
 
 	if jobid == "" {
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -2,7 +2,6 @@ package sidecar_test
 
 import (
 	"context"
-	"github.com/d-hayashi/k8s-slurm-injector/internal/config_map"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/d-hayashi/k8s-slurm-injector/internal/config_map"
 	"github.com/d-hayashi/k8s-slurm-injector/internal/mutation/sidecar"
 	"github.com/d-hayashi/k8s-slurm-injector/internal/ssh_handler"
 )

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -2,6 +2,7 @@ package sidecar_test
 
 import (
 	"context"
+	"github.com/d-hayashi/k8s-slurm-injector/internal/config_map"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -269,7 +270,8 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			require := require.New(t)
 
 			sshHandler, _ := ssh_handler.Dummy()
-			injector, _ := sidecar.NewSidecarInjector(sshHandler)
+			configMapHandler, _ := config_map.NewDummyConfigMapHandler()
+			injector, _ := sidecar.NewSidecarInjector(sshHandler, configMapHandler)
 			injector.SetNodes([]string{"node1"})
 
 			_, err := injector.Inject(context.TODO(), test.obj)


### PR DESCRIPTION
## What?
Change specification to create a config-map at the time a pod/job is mutated to inject sidecars

## Why?
To make job-watcher work more reliable.