### PR TITLE
Better support for GPUs

### DIFF
--- a/internal/http/slurm/handler.go
+++ b/internal/http/slurm/handler.go
@@ -245,7 +245,11 @@ func (s JobEnvToConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 		// Substitute
 		if isUse {
-			env[key] = value
+			if key == "CUDA_VISIBLE_DEVICES" {
+				env["NVIDIA_VISIBLE_DEVICES"] = value
+			}else {
+				env[key] = value
+			}
 		}
 	}
 

--- a/internal/http/slurm/handler.go
+++ b/internal/http/slurm/handler.go
@@ -247,7 +247,7 @@ func (s JobEnvToConfigMapHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		if isUse {
 			if key == "CUDA_VISIBLE_DEVICES" {
 				env["NVIDIA_VISIBLE_DEVICES"] = value
-			}else {
+			} else {
 				env[key] = value
 			}
 		}

--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -481,13 +481,9 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 		)
 
 		// Remove `spec.containers[].resources.limits.nvidia.com/gpu`
-		if _, ok := podSpec.Containers[i].Resources.Limits["nvidia.com/gpu"]; ok {
-			delete(podSpec.Containers[i].Resources.Limits, "nvidia.com/gpu")
-		}
+		delete(podSpec.Containers[i].Resources.Limits, "nvidia.com/gpu")
 		// Remove `spec.containers[].resources.requests.nvidia.com/gpu`
-		if _, ok := podSpec.Containers[i].Resources.Requests["nvidia.com/gpu"]; ok {
-			delete(podSpec.Containers[i].Resources.Requests, "nvidia.com/gpu")
-		}
+		delete(podSpec.Containers[i].Resources.Requests, "nvidia.com/gpu")
 	}
 
 	// Add container `slurm-watcher` as sidecar

--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -479,6 +479,15 @@ func (s sidecarinjector) mutateObject(obj metav1.Object) error {
 				},
 			},
 		)
+
+		// Remove `spec.containers[].resources.limits.nvidia.com/gpu`
+		if _, ok := podSpec.Containers[i].Resources.Limits["nvidia.com/gpu"]; ok {
+			delete(podSpec.Containers[i].Resources.Limits, "nvidia.com/gpu")
+		}
+		// Remove `spec.containers[].resources.requests.nvidia.com/gpu`
+		if _, ok := podSpec.Containers[i].Resources.Requests["nvidia.com/gpu"]; ok {
+			delete(podSpec.Containers[i].Resources.Requests, "nvidia.com/gpu")
+		}
 	}
 
 	// Add container `slurm-watcher` as sidecar

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -283,6 +283,8 @@ func TestSidecarinjector_Inject(t *testing.T) {
 				if len(test.obj.(*corev1.Pod).Spec.Containers) > 1 {
 					assert.NotEmpty(test.obj.(*corev1.Pod).Spec.Containers[0].Lifecycle)
 					assert.True(*test.obj.(*corev1.Pod).Spec.ShareProcessNamespace)
+					assert.Empty(test.obj.(*corev1.Pod).Spec.Containers[0].Resources.Limits["nvidia.com/gpu"])
+					assert.Empty(test.obj.(*corev1.Pod).Spec.Containers[0].Resources.Requests["nvidia.com/gpu"])
 				}
 			case *batchv1.Job:
 				assert.Equal(test.expObj.(*batchv1.Job).ObjectMeta, test.obj.(*batchv1.Job).ObjectMeta)


### PR DESCRIPTION
## What?
Resolves #10 
- Set `NVIDIA_VISIBLE_DEVICES` instead of `CUDA_VISIBLE_DEVICES`
- Mutate to remove `spec.containers[].resources.limits.nvidia.com/gpu` and `spec.containers[].resources.requests.nvidia.com/gpu`

## Why?
To improve GPU support.
(By setting `NVIDIA_VISIBLE_DEVICES`, only the specified GPUs will be visible inside the container)