### PR TITLE
Add option `target-namespace`

### DIFF
--- a/cmd/k8s-slurm-injector/config.go
+++ b/cmd/k8s-slurm-injector/config.go
@@ -21,8 +21,9 @@ type CmdConfig struct {
 	EnableIngressSingleHost bool
 	MinSMScrapeInterval     time.Duration
 
-	SSHDestination string
-	SSHPort        string
+	SSHDestination   string
+	SSHPort          string
+	TargetNamespaces string
 }
 
 // NewCmdConfig returns a new command configuration.
@@ -42,6 +43,7 @@ func NewCmdConfig() (*CmdConfig, error) {
 	app.Flag("tls-key-file-path", "the path for the webhook HTTPS server TLS key file.").StringVar(&c.TLSKeyFilePath)
 	app.Flag("webhook-ssh-destination", "SSH destination where slurm controller is working").StringVar(&c.SSHDestination)
 	app.Flag("webhook-ssh-port", "SSH port").Default("22").StringVar(&c.SSHPort)
+	app.Flag("target-namespaces", "Target namespaces (comma separated)").StringVar(&c.TargetNamespaces)
 	app.Flag("webhook-sm-min-scrape-interval", "the minimum screate interval service monitors can have.").DurationVar(&c.MinSMScrapeInterval)
 
 	_, err := app.Parse(os.Args[1:])

--- a/internal/mutation/finalizer/finalizer.go
+++ b/internal/mutation/finalizer/finalizer.go
@@ -20,13 +20,18 @@ type Finalizer interface {
 }
 
 // NewFinalizer returns a new finalizer that will finalize slurm jobs.
-func NewFinalizer(configMapHandler config_map.ConfigMapHandler, slurmHandler slurm_handler.SlurmHandler) (Finalizer, error) {
-	return &finalizer{configMapHandler: configMapHandler, slurmHandler: slurmHandler}, nil
+func NewFinalizer(
+	configMapHandler config_map.ConfigMapHandler,
+	slurmHandler slurm_handler.SlurmHandler,
+	targetNamespace []string,
+) (Finalizer, error) {
+	return &finalizer{configMapHandler: configMapHandler, slurmHandler: slurmHandler, targetNamespace: targetNamespace}, nil
 }
 
 type finalizer struct {
 	configMapHandler config_map.ConfigMapHandler
 	slurmHandler     slurm_handler.SlurmHandler
+	targetNamespace  []string
 }
 
 func (f finalizer) Finalize(_ context.Context, obj metav1.Object) (string, error) {
@@ -46,7 +51,7 @@ func (f finalizer) Finalize(_ context.Context, obj metav1.Object) (string, error
 	}
 
 	// Check if injection is enabled
-	isInjectionEnabled := sidecar.IsInjectionEnabled(obj)
+	isInjectionEnabled := sidecar.IsInjectionEnabled(obj, f.targetNamespace)
 	if !isInjectionEnabled {
 		return "", nil
 	}

--- a/internal/mutation/finalizer/finalizer_test.go
+++ b/internal/mutation/finalizer/finalizer_test.go
@@ -141,7 +141,8 @@ func TestFinalizer_Finalize(t *testing.T) {
 
 			dummyConfigMapHandler, _ := config_map.NewDummyConfigMapHandler()
 			dummySlurmHandler, _ := slurm_handler.NewDummySlurmHandler()
-			handler, _ := finalizer.NewFinalizer(dummyConfigMapHandler, dummySlurmHandler)
+			targetNamespace := []string{"target-.*"}
+			handler, _ := finalizer.NewFinalizer(dummyConfigMapHandler, dummySlurmHandler, targetNamespace)
 
 			_, err := handler.Finalize(context.TODO(), test.obj)
 			require.NoError(err)


### PR DESCRIPTION
## What?
Support specifying namespaces to inject slurm-jobs

## Why?
To cover the case when pods' labels cannot be modified