### PR TITLE
Fix the bug that slurm-jobs are not injected with deployments

### DIFF
--- a/deploy/sample-deployment.yaml
+++ b/deploy/sample-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample-deployment
+  template:
+    metadata:
+      labels:
+        app: sample-deployment
+    spec:
+      containers:
+        - name: busybox
+          image: curlimages/curl:7.75.0
+          env:
+            - name: K8S_SLURM_INJECTOR_INJECTION
+              value: enabled
+            - name: K8S_SLURM_INJECTOR_NODE_SPECIFICATION_MODE
+              value: manual
+            - name: K8S_SLURM_INJECTOR_PARTITION
+              value: ubuntu
+            - name: K8S_SLURM_INJECTOR_NODE
+              value: nsx
+          args:
+            - sleep
+            - "300"
+      restartPolicy: Always

--- a/deploy/sample-statefulset.yaml
+++ b/deploy/sample-statefulset.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sample-statefulset
+spec:
+  serviceName: "sample-statefulset"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample-statefulset
+  template:
+    metadata:
+      labels:
+        app: sample-statefulset
+    spec:
+      containers:
+        - name: busybox
+          image: curlimages/curl:7.75.0
+          env:
+            - name: K8S_SLURM_INJECTOR_INJECTION
+              value: enabled
+            - name: K8S_SLURM_INJECTOR_NODE_SPECIFICATION_MODE
+              value: manual
+            - name: K8S_SLURM_INJECTOR_PARTITION
+              value: ubuntu
+            - name: K8S_SLURM_INJECTOR_NODE
+              value: nsx
+          args:
+            - sleep
+            - "300"
+      restartPolicy: Always

--- a/internal/mutation/finalizer/finalizer_test.go
+++ b/internal/mutation/finalizer/finalizer_test.go
@@ -110,13 +110,13 @@ func TestFinalizer_Finalize(t *testing.T) {
 		"Having a pod without labels, the labels should not be mutated.": {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},
@@ -125,13 +125,13 @@ func TestFinalizer_Finalize(t *testing.T) {
 		"Having a service, the labels should not be mutated.": {
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},

--- a/internal/mutation/finalizer/finalizer_test.go
+++ b/internal/mutation/finalizer/finalizer_test.go
@@ -111,11 +111,13 @@ func TestFinalizer_Finalize(t *testing.T) {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 		},
@@ -124,11 +126,13 @@ func TestFinalizer_Finalize(t *testing.T) {
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 		},

--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -161,7 +161,7 @@ func getObjectNamespace(obj metav1.Object) (string, error) {
 			if err == nil {
 				if len(owner.Items) == 0 {
 					continue
-				}else if len(owner.Items) > 1 {
+				} else if len(owner.Items) > 1 {
 					return "", fmt.Errorf("failed to get namespace: more than one %s were found with name %s", ownerReference.Kind, ownerReference.Name)
 				}
 				return owner.Items[0].Namespace, nil
@@ -256,7 +256,6 @@ func (s sidecarinjector) getJobInformation(obj metav1.Object, jobInfo *JobInform
 	ngpus := int64(0)
 	time := int64(0)
 	name := ""
-
 
 	switch v := obj.(type) {
 	case *corev1.Pod:

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -27,7 +27,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 		"Having a pod, the labels should be mutated.": {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
@@ -40,7 +40,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
@@ -147,7 +147,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 		"Having a job, the labels should be mutated.": {
 			obj: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
@@ -160,7 +160,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			},
 			expObj: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
@@ -190,7 +190,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 		"Having a pod with containers": {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"k8s-slurm-injector/injection":               "enabled",
@@ -218,7 +218,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"k8s-slurm-injector/injection":               "enabled",
@@ -258,7 +258,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 		"Having a pod with containers with environment variables": {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 				Spec: corev1.PodSpec{
@@ -288,7 +288,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Annotations: map[string]string{
 						"k8s-slurm-injector/namespace":               "default",

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -28,6 +28,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
 						"test2":                        "value2",
@@ -40,6 +41,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
 						"test2":                        "value2",
@@ -48,7 +50,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 						"k8s-slurm-injector/node":                    "node1",
 					},
 					Annotations: map[string]string{
-						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/namespace":               "default",
 						"k8s-slurm-injector/object-name":             "pod-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "manual",
@@ -146,6 +148,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			obj: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
 						"test2":                        "value2",
@@ -158,6 +161,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			expObj: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
 						"test2":                        "value2",
@@ -166,7 +170,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 						"k8s-slurm-injector/node":                    "node1",
 					},
 					Annotations: map[string]string{
-						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/namespace":               "default",
 						"k8s-slurm-injector/object-name":             "job-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "manual",
@@ -187,6 +191,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"k8s-slurm-injector/injection":               "enabled",
 						"k8s-slurm-injector/node-specification-mode": "auto",
@@ -214,12 +219,13 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"k8s-slurm-injector/injection":               "enabled",
 						"k8s-slurm-injector/node-specification-mode": "auto",
 					},
 					Annotations: map[string]string{
-						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/namespace":               "default",
 						"k8s-slurm-injector/object-name":             "pod-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "auto",
@@ -253,6 +259,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -282,8 +289,9 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Annotations: map[string]string{
-						"k8s-slurm-injector/namespace":               "",
+						"k8s-slurm-injector/namespace":               "default",
 						"k8s-slurm-injector/object-name":             "pod-test",
 						"k8s-slurm-injector/status":                  "injected",
 						"k8s-slurm-injector/node-specification-mode": "",

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -70,7 +70,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 		"Having a pod with labels without injection, the labels should not be mutated.": {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
@@ -83,7 +83,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
@@ -136,13 +136,13 @@ func TestSidecarinjector_Inject(t *testing.T) {
 		"Having a pod without labels, the labels should not be mutated.": {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},
@@ -249,13 +249,13 @@ func TestSidecarinjector_Inject(t *testing.T) {
 		"Having a service, the labels should not be mutated.": {
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
+					Name:      "test",
 					Namespace: "default",
 				},
 			},

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -71,6 +71,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
 						"test2":                        "value2",
@@ -83,6 +84,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 					Labels: map[string]string{
 						"test1":                        "value1",
 						"test2":                        "value2",
@@ -135,11 +137,13 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 		},
@@ -246,11 +250,13 @@ func TestSidecarinjector_Inject(t *testing.T) {
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 			expObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Namespace: "default",
 				},
 			},
 		},


### PR DESCRIPTION
## What?
Fix the bug that slurm-jobs are not injected with deployments due to failing to get namespace and name of ReplicaSets.

## Why?
Bug fix