### PR TITLE
Change the default job-name to `(namespace)-(pod-name)`

### DIFF
--- a/internal/slurm_handler/slurm_handler.go
+++ b/internal/slurm_handler/slurm_handler.go
@@ -81,7 +81,11 @@ func (h *handler) fetchSlurmNodeInfo() error {
 func constructCommand(jobInfo *sidecar.JobInformation) ([]string, error) {
 	jobName := jobInfo.Name
 	if jobName == "" {
-		jobName = "k8s-slurm-injector-job"
+		if jobInfo.Namespace == "" || jobInfo.ObjectName == "" {
+			jobName = "k8s-slurm-injector-job"
+		}else {
+			jobName = fmt.Sprintf("%s-%s", jobInfo.Namespace, jobInfo.ObjectName)
+		}
 	}
 
 	commands := []string{

--- a/internal/slurm_handler/slurm_handler.go
+++ b/internal/slurm_handler/slurm_handler.go
@@ -83,7 +83,7 @@ func constructCommand(jobInfo *sidecar.JobInformation) ([]string, error) {
 	if jobName == "" {
 		if jobInfo.Namespace == "" || jobInfo.ObjectName == "" {
 			jobName = "k8s-slurm-injector-job"
-		}else {
+		} else {
 			jobName = fmt.Sprintf("%s-%s", jobInfo.Namespace, jobInfo.ObjectName)
 		}
 	}

--- a/internal/slurm_handler/slurm_handler_test.go
+++ b/internal/slurm_handler/slurm_handler_test.go
@@ -52,8 +52,8 @@ func TestSbatchHandler_constructCommand(t *testing.T) {
 		},
 		"case3": {
 			sidecar.JobInformation{
-				Partition: "partition1",
-				Namespace: "ns",
+				Partition:  "partition1",
+				Namespace:  "ns",
 				ObjectName: "abc",
 			},
 			[]string{

--- a/internal/slurm_handler/slurm_handler_test.go
+++ b/internal/slurm_handler/slurm_handler_test.go
@@ -50,6 +50,35 @@ func TestSbatchHandler_constructCommand(t *testing.T) {
 				"--time=3600",
 			},
 		},
+		"case3": {
+			sidecar.JobInformation{
+				Partition: "partition1",
+				Namespace: "ns",
+				ObjectName: "abc",
+			},
+			[]string{
+				"sbatch",
+				"--parsable",
+				"--output=/dev/null",
+				"--error=/dev/null",
+				"--job-name=ns-abc",
+				"--partition=partition1",
+			},
+		},
+		"case4": {
+			sidecar.JobInformation{
+				Partition: "partition1",
+				Namespace: "ns",
+			},
+			[]string{
+				"sbatch",
+				"--parsable",
+				"--output=/dev/null",
+				"--error=/dev/null",
+				"--job-name=k8s-slurm-injector-job",
+				"--partition=partition1",
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## What?
Change the default job-name from `k8s-slurm-injector-job` to `(namespace)-(pod-name)`

## Why?
To improve visibility in Slurm