### PR TITLE
Disable mutation on resource updates

### DIFF
--- a/deploy/webhooks.yaml.tpl
+++ b/deploy/webhooks.yaml.tpl
@@ -21,7 +21,7 @@ webhooks:
         path: /wh/mutating/injectsidecar
       caBundle: CA_BUNDLE
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["cronjobs", "jobs", "pods"]

--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -105,6 +105,19 @@ func IsInjectionEnabled(obj metav1.Object, targetNamespaces []string, objectName
 		}
 	}
 
+	// Get annotations
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	// Check labels
+	for key, value := range annotations {
+		if key == "k8s-slurm-injector/status" && value == "injected" {
+			return false
+		}
+	}
+
 	// Check namespaces
 	var namespace string
 	var err error

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -325,7 +325,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 						"k8s-slurm-injector/node-specification-mode": "manual",
 						"k8s-slurm-injector/node":                    "node1",
 					},
-					Annotations: map[string]string {
+					Annotations: map[string]string{
 						"k8s-slurm-injector/status": "injected",
 					},
 				},
@@ -342,7 +342,7 @@ func TestSidecarinjector_Inject(t *testing.T) {
 						"k8s-slurm-injector/node":                    "node1",
 					},
 					Annotations: map[string]string{
-						"k8s-slurm-injector/status":                  "injected",
+						"k8s-slurm-injector/status": "injected",
 					},
 				},
 			},

--- a/internal/mutation/sidecar/sidecar_test.go
+++ b/internal/mutation/sidecar/sidecar_test.go
@@ -313,6 +313,40 @@ func TestSidecarinjector_Inject(t *testing.T) {
 				},
 			},
 		},
+		"Having a pod that slurm job has already been injected, the labels should not be mutated.": {
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Labels: map[string]string{
+						"test1":                        "value1",
+						"test2":                        "value2",
+						"k8s-slurm-injector/injection": "enabled",
+						"k8s-slurm-injector/node-specification-mode": "manual",
+						"k8s-slurm-injector/node":                    "node1",
+					},
+					Annotations: map[string]string {
+						"k8s-slurm-injector/status": "injected",
+					},
+				},
+			},
+			expObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Labels: map[string]string{
+						"test1":                        "value1",
+						"test2":                        "value2",
+						"k8s-slurm-injector/injection": "enabled",
+						"k8s-slurm-injector/node-specification-mode": "manual",
+						"k8s-slurm-injector/node":                    "node1",
+					},
+					Annotations: map[string]string{
+						"k8s-slurm-injector/status":                  "injected",
+					},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## What?
Disable injecting Slurm jobs when Pods/Jobs are updated

## Why?
Mutating already-mutated objects fails with `Duplicate value`