### PR TITLE
Fix the bug that PENDING jobs were removed from Slurm

### DIFF
--- a/internal/slurm_handler/slurm_handler.go
+++ b/internal/slurm_handler/slurm_handler.go
@@ -133,7 +133,7 @@ func (h handler) SBatch(jobInfo *sidecar.JobInformation) (string, error) {
 		out, err = h.ssh.RunCommandCombined(command)
 	}
 
-	return string(out), err
+	return strings.Replace(string(out), "\n", "", -1), err
 }
 
 func (h handler) GetEnv(jobid string) (string, error) {


### PR DESCRIPTION
## What?
Fix the bug that jobs in state `PENDING` were remove from Slurm by watcher.

## Why?
Bug fix