### PR TITLE
Fix the bug that slurm-injection could not be disabled

### DIFF
--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -103,6 +103,9 @@ func IsInjectionEnabled(obj metav1.Object, targetNamespaces []string, objectName
 		if key == "k8s-slurm-injector/injection" && value == "enabled" {
 			isInjectionEnabled = true
 		}
+		if key == "k8s-slurm-injector/injection" && value == "disabled" {
+			return false
+		}
 	}
 
 	// Get annotations
@@ -152,6 +155,9 @@ func IsInjectionEnabled(obj metav1.Object, targetNamespaces []string, objectName
 		for _, env := range container.Env {
 			if env.Name == "K8S_SLURM_INJECTOR_INJECTION" && env.Value == "enabled" {
 				isInjectionEnabled = true
+			}
+			if env.Name == "K8S_SLURM_INJECTOR_INJECTION" && env.Value == "disabled" {
+				return false
 			}
 		}
 	}


### PR DESCRIPTION
## What?
Fix the bug that slurm-injection could not be disabled even if the following label is added.
`"k8s-slurm-injector/injection": "disabled"`

## Why?
Bug fix