### PR TITLE
Fix the bug that label `k8s-slurm-injector/injection=disabled` had no effect

### DIFF
--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -857,11 +857,9 @@ func (s sidecarinjector) Inject(_ context.Context, obj metav1.Object) (string, e
 
 	// Check labels
 	labels := obj.GetLabels()
-	if labels != nil {
-		for key, value := range labels {
-			if key == "k8s-slurm-injector/injection" && value == "disabled" {
-				return "", nil
-			}
+	for key, value := range labels {
+		if key == "k8s-slurm-injector/injection" && value == "disabled" {
+			return "", nil
 		}
 	}
 

--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -855,6 +855,16 @@ func (s sidecarinjector) Inject(_ context.Context, obj metav1.Object) (string, e
 		return "", nil
 	}
 
+	// Check labels
+	labels := obj.GetLabels()
+	if labels != nil {
+		for key, value := range labels {
+			if key == "k8s-slurm-injector/injection" && value == "disabled" {
+				return "", nil
+			}
+		}
+	}
+
 	// Get object's namespace
 	objectNamespace, err := getObjectNamespace(obj)
 	if err != nil {


### PR DESCRIPTION
## What?
Fix the bug that label `k8s-slurm-injector/injection=disabled` had no effect when namespace could not be retrieved

## Why?
Bug fix