### PR TITLE
Add feature to label nodes based on Slurm's reports

### DIFF
--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -92,6 +92,9 @@ rules:
   - apiGroups: [ "apps" ]
     resources: [ "replicasets" ]
     verbs: [ "get", "list" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "list", "patch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/webhooks.yaml.tpl
+++ b/deploy/webhooks.yaml.tpl
@@ -24,7 +24,7 @@ webhooks:
       - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["cronjobs", "jobs", "pods"]
+        resources: ["pods"]
   - name: delete-slurm-job.d-hayashi.dev
     objectSelector:
       matchExpressions:
@@ -43,4 +43,4 @@ webhooks:
       - operations: ["DELETE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["cronjobs", "jobs", "pods"]
+        resources: ["pods"]


### PR DESCRIPTION
## What?
Add feature to update the following labels of nodes based on Slurm's reports:
- `slurm-num-cpus-free`: Number of CPUs not allocated to any jobs
- `slurm-num-gpus-free`: Number of GPUs not allocated to any jobs
- `slurm-mem-free`: The amount of free memory

## Why?
To use NodeAffinity