### PR TITLE
fix: patch node affinity without ignoring the existing items

### DIFF
--- a/internal/mutation/sidecar/sidecar.go
+++ b/internal/mutation/sidecar/sidecar.go
@@ -738,9 +738,11 @@ func (s sidecarinjector) mutateObject(obj metav1.Object, objectNamespace string)
 			podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms =
 				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		} else {
-			podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms =
-				append(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-					nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms...)
+			for i := range podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+				podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions =
+					append(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions,
+						nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions...)
+			}
 		}
 
 	}


### PR DESCRIPTION
## What?
Append pod affinity with key `slurm-num-gpus-free` in `podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions` instead of `podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms` 

## Why?
Items in `podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms` are ORed, so appending a new item into the array results in ignoring the the original items.